### PR TITLE
support reuse of Gurobi environment for multistage models

### DIFF
--- a/docs/src/User_Guide/model_configuration.md
+++ b/docs/src/User_Guide/model_configuration.md
@@ -125,6 +125,7 @@ The following tables summarize the model settings parameters and their default/p
 
 |**Parameter** | **Description**|
 | :------------ | :-----------|
+|Solver | OPTIONAL name of solver. Default is "HiGHS" effectively. It is necessary to set `Solver: "Gurobi"` when [reusing the same gurobi environment for multiple solves](https://github.com/jump-dev/Gurobi.jl?tab=readme-ov-file#reusing-the-same-gurobi-environment-for-multiple-solves).
 |EnableJuMPStringNames | Flag to enable/disable JuMP string names to improve the performance.|
 ||1 = enable JuMP string names.|
 ||0 = disable JuMP string names.|

--- a/src/case_runners/case_runner.jl
+++ b/src/case_runners/case_runner.jl
@@ -65,7 +65,8 @@ function run_genx_case_simple!(case::AbstractString, mysetup::Dict, optimizer::A
 
     ### Configure solver
     println("Configuring Solver")
-    OPTIMIZER = configure_solver(settings_path, optimizer)
+    solver_name = lowercase(get(mysetup, "Solver", ""))
+    OPTIMIZER = configure_solver(settings_path, optimizer; solver_name=solver_name)
 
     #### Running a case
 
@@ -137,7 +138,8 @@ function run_genx_case_multistage!(case::AbstractString, mysetup::Dict, optimize
 
     ### Configure solver
     println("Configuring Solver")
-    OPTIMIZER = configure_solver(settings_path, optimizer)
+    solver_name = lowercase(get(mysetup, "Solver", ""))
+    OPTIMIZER = configure_solver(settings_path, optimizer; solver_name=solver_name)
 
     model_dict = Dict()
     inputs_dict = Dict()

--- a/src/configure_solver/configure_solver.jl
+++ b/src/configure_solver/configure_solver.jl
@@ -19,8 +19,10 @@ Currently supported solvers include: "Gurobi", "CPLEX", "Clp", "Cbc", or "SCIP"
 # Returns
 - `optimizer::MathOptInterface.OptimizerWithAttributes`: the configured optimizer instance.
 """
-function configure_solver(solver_settings_path::String, optimizer::Any)
-    solver_name = infer_solver(optimizer)
+function configure_solver(solver_settings_path::String, optimizer::Any; solver_name::String="")
+    if isempty(solver_name)
+        solver_name = infer_solver(optimizer)
+    end
     path = joinpath(solver_settings_path, solver_name * "_settings.yml")
 
     configure_functions = Dict("highs" => configure_highs,


### PR DESCRIPTION
GenX builds all JuMP models for multistage models before solving and recording results. These changes allow Gurobi to work with building multiple models with the Gurobi.Optimizer.

To pass Gurobi.Optimizer to GenX do something like:
```julia
using GenX
using Gurobi


if !(@isdefined GRB_ENV)  # the whole point is to only create GRB_ENV once per Julia session
    const GRB_ENV = Gurobi.Env()
end

run_genx_case!(dirname(@__FILE__), () -> Gurobi.Optimizer(GRB_ENV))


```