### PR TITLE
Update write_outputs.jl

### DIFF
--- a/src/write_outputs/write_outputs.jl
+++ b/src/write_outputs/write_outputs.jl
@@ -259,18 +259,27 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
         println(elapsed_time_angles)
     end
 
-    # Temporary! Suppress these outputs until we know that they are compatable with multi-stage modeling
+    # Temporary! Suppress these outputs until we know that they are compatable with multi-stage
+    # modeling
+    if output_settings_d["WriteTimeWeights"]
+        elapsed_time_time_weights = @elapsed write_time_weights(path, inputs)
+        println("Time elapsed for writing time weights is")
+        println(elapsed_time_time_weights)
+    end
+    if has_duals(EP) == 1
+        if output_settings_d["WritePrice"]
+            elapsed_time_price = @elapsed write_price(path, inputs, setup, EP)
+            println("Time elapsed for writing price is")
+            println(elapsed_time_price)
+        end
+    end
+
     if setup["MultiStage"] == 0
         dfEnergyRevenue = DataFrame()
         dfChargingcost = DataFrame()
         dfSubRevenue = DataFrame()
         dfRegSubRevenue = DataFrame()
         if has_duals(EP) == 1
-            if output_settings_d["WritePrice"]
-                elapsed_time_price = @elapsed write_price(path, inputs, setup, EP)
-                println("Time elapsed for writing price is")
-                println(elapsed_time_price)
-            end
 
             if output_settings_d["WriteEnergyRevenue"] ||
                output_settings_d["WriteNetRevenue"]
@@ -304,12 +313,6 @@ function write_outputs(EP::Model, path::AbstractString, setup::Dict, inputs::Dic
                 println("Time elapsed for writing subsidy is")
                 println(elapsed_time_subsidy)
             end
-        end
-
-        if output_settings_d["WriteTimeWeights"]
-            elapsed_time_time_weights = @elapsed write_time_weights(path, inputs)
-            println("Time elapsed for writing time weights is")
-            println(elapsed_time_time_weights)
         end
 
         dfESRRev = DataFrame()


### PR DESCRIPTION
write_outputs.jl has a bunch of outputs within a `if setup["MultiStage"] == 0` block, which means that when running multistage models we cannot get these outputs. This PR pulls a couple of outputs out of the if block (they are still only written based on other input settings). 